### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/SHANTANU.pm
+++ b/lib/Dist/Zilla/PluginBundle/SHANTANU.pm
@@ -21,7 +21,7 @@ use Dist::Zilla::PluginBundle::Git 2.028;
 use Dist::Zilla::Plugin::Git::NextVersion;
 use Dist::Zilla::Plugin::AutoMetaResourcesPrefixed;
 
-use Dist::Zilla::Plugin::ContributorsFromGit;
+use Dist::Zilla::Plugin::Git::Contributors;
 
 use Dist::Zilla::Plugin::PruneCruft;
 use Dist::Zilla::Plugin::ManifestSkip;
@@ -390,7 +390,7 @@ sub configure {
         (
             $self->no_git
             ? ()
-            : 'ContributorsFromGit'
+            : 'Git::Contributors'
         ),
 
         [


### PR DESCRIPTION
This plugin has unresolved issues on MSWin32 and with handling unicode names, so I forked it last year.
